### PR TITLE
Linebreaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ correctly in `~/.ncTelegram.conf`.
 
 - Use `ctrl+o` to open the last file or url sent to the current channel.
 
-- Use `ctrl+j` to insert a linebreak.
+- Use `ctrl+r` to insert a linebreak.
 
 - To send files you can simply drag and drop them into your terminal or send as
 a message their path between single quotes (').

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ correctly in `~/.ncTelegram.conf`.
 
 - Use `ctrl+o` to open the last file or url sent to the current channel.
 
+- Use `ctrl+n` to insert a linebreak.
+
 - To send files you can simply drag and drop them into your terminal or send as
 a message their path between single quotes (').
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ correctly in `~/.ncTelegram.conf`.
 
 - Use `ctrl+o` to open the last file or url sent to the current channel.
 
-- Use `ctrl+n` to insert a linebreak.
+- Use `ctrl+j` to insert a linebreak.
 
 - To send files you can simply drag and drop them into your terminal or send as
 a message their path between single quotes (').

--- a/ncTelegram.conf
+++ b/ncTelegram.conf
@@ -52,6 +52,7 @@ right = l
 up = k
 down = j
 insert_text = i
+line_break = ctrl r
 quit = q
 open_file = ctrl o
 next_chan = ctrl n

--- a/ncTelegram/ui_msgsendwidget.py
+++ b/ncTelegram/ui_msgsendwidget.py
@@ -226,7 +226,7 @@ class MessageSendWidget(urwid.Filler):
             self.cur_text = ""
 
         # linebreaks
-        elif key == 'ctrl n':
+        elif key == 'ctrl l':
             self.widgetEdit.insert_text("\n")
 
         # Autocompletion

--- a/ncTelegram/ui_msgsendwidget.py
+++ b/ncTelegram/ui_msgsendwidget.py
@@ -225,6 +225,10 @@ class MessageSendWidget(urwid.Filler):
             self.widgetEdit.set_edit_text("")
             self.cur_text = ""
 
+        # linebreaks
+        elif key == 'ctrl n':
+            self.widgetEdit.insert_text("\n")
+
         # Autocompletion
         elif key == 'tab' and self.widgetEdit.get_edit_text().rsplit(' ', 1)[-1].startswith("@"):
             self.autocomplete()

--- a/ncTelegram/ui_msgsendwidget.py
+++ b/ncTelegram/ui_msgsendwidget.py
@@ -226,7 +226,7 @@ class MessageSendWidget(urwid.Filler):
             self.cur_text = ""
 
         # linebreaks
-        elif key == 'ctrl l':
+        elif key == self.Telegram_ui.conf['keymap']['line_break']:
             self.widgetEdit.insert_text("\n")
 
         # Autocompletion

--- a/nctelegram
+++ b/nctelegram
@@ -55,6 +55,7 @@ config_full['keymap']['down'] = config['keymap'].get('down', 'j')
 config_full['keymap']['quit'] = config['keymap'].get('quit', 'q')
 config_full['keymap']['insert_text'] = config['keymap'].get('insert_text', 'i')
 config_full['keymap']['open_file'] = config['keymap'].get('open_file', 'ctrl o')
+config_full['keymap']['line_break'] = config['keymap'].get('line_break', 'ctrl r')
 config_full['keymap']['next_chan'] = config['keymap'].get('next_chan', 'ctrl n')
 config_full['keymap']['prev_chan'] = config['keymap'].get('prev_chan', 'ctrl p')
 


### PR DESCRIPTION
This adds `ctrl l` as a keybinding to insert a linebreak into the message.

I tried using something like `shift enter`, but when pressing shift+enter, `key` is only set to `"enter"`. I'm not sure whether that's intended or I missed something, but I think `ctrl l` works for now.