### PR TITLE
Ctrl w behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ a message their path between single quotes (').
 - Vim-like key bindings are also available, use `hjkl` to navigate between
 lists, use `i` to select the text area and `esc` to leave it.
 
+- You can also use `ctrl+w` to remove words left of the cursor and `ctrl+u` to remove the whole line.
+
 - Use `shift + Up` or `shift + Down` to navigate in your own message history.
 
 #### Troubleshooting

--- a/ncTelegram/ui_msgsendwidget.py
+++ b/ncTelegram/ui_msgsendwidget.py
@@ -241,19 +241,18 @@ class MessageSendWidget(urwid.Filler):
 
         # deletion of characters left of the cursor until the next stop character
         elif key == 'ctrl w':
-            STOPCHARACTERS = " -/.,:"
+            STOPCHARACTERS = r'[\s\W]'
 
             edit_text = self.widgetEdit.get_edit_text()
-            edit_text = re.sub(r'\s+$', '', edit_text)
 
             # the widget considers the caption when calculating the cursor position
             cursor_pos = self.widgetEdit.get_cursor_coords((size[0],))[0] - len(TEXT_CAPTION)
             i = 0
-            c = ""
             for character in reversed(edit_text[:cursor_pos]):
-                i += 1
-                if character in STOPCHARACTERS:
+                if i > 0 and re.match(STOPCHARACTERS, character):
                     break
+                else:
+                    i += 1
 
             new_edit_text = edit_text[:cursor_pos - i] + edit_text[cursor_pos:]
             self.widgetEdit.set_edit_text(new_edit_text)


### PR DESCRIPTION
Hi,
this changes the behavior of `ctrl w` to remove the word before the cursor instead of the last word up until the first found stop character (whitespace or non-alphanumeric character).

The behavior is now _almost_ as in zsh I think. (not sure about other shells)
A difference I've noticed so far: when using `ctrl w` after a series of stop characters, e.g. "...", only the last is removed. My shell removes all of them.

P.S.: Thanks a lot for this client. Since my last PR this has almost completely replaced the Telegram webapp for me.